### PR TITLE
Fix `corepack` Enabling, Fix Mac ARM Downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +682,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.4.6",
+ "rustc-serialize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+dependencies = [
+ "num-traits",
+ "rustc-serialize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rustc-serialize",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +784,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "spectral",
  "tar",
  "ureq",
  "zip",
@@ -739,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -847,13 +923,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
@@ -864,8 +953,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -882,7 +986,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -950,6 +1063,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustix"
@@ -1056,6 +1175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spectral"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
+dependencies = [
+ "num",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +1231,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ itertools = "0.10.5"
 node-semver = "2.1.0"
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
+spectral = "0.6.0"
 ureq = { version = "2.5.0", features = ["json"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/archives.rs
+++ b/src/archives.rs
@@ -63,7 +63,7 @@ pub fn extract_archive(bytes: Vec<u8>, path: &Path) -> Result<()> {
     let mut archive = Archive::new(tar);
 
     let version_dir_path = path.to_owned();
-    create_dir_all(version_dir_path.to_owned()).expect("fuck");
+    create_dir_all(&version_dir_path).expect("fuck");
 
     println!("Extracting...");
 
@@ -72,11 +72,11 @@ pub fn extract_archive(bytes: Vec<u8>, path: &Path) -> Result<()> {
         .map_err(anyhow::Error::from)?
         .filter_map(|e| e.ok())
         .map(|mut entry| -> Result<Unpacked> {
-            let file_path = entry.path()?.to_owned();
+            let file_path = entry.path()?;
             let file_path = file_path.to_str().unwrap();
 
             let new_path: PathBuf = if let Some(index) = file_path.find('/') {
-                path.to_owned().join(file_path[index + 1..].to_owned())
+                path.to_owned().join(&file_path[index + 1..])
             } else {
                 // This happens if it's the root index, the base folder
                 path.to_owned()
@@ -105,7 +105,7 @@ pub fn extract_archive(bytes: Vec<u8>, path: &Path) -> Result<()> {
         ));
     }
 
-    println!("Extracted to {:?}", version_dir_path);
+    println!("Extracted to {version_dir_path:?}");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{bail, Result};
+#[cfg(windows)]
+use anyhow::bail;
+use anyhow::Result;
 use clap::{Parser, ValueHint};
 
 use crate::subcommand::{

--- a/src/node_version.rs
+++ b/src/node_version.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Borrow,
     cmp::Ordering,
     collections::HashMap,
     fs::{read_link, remove_dir_all},
@@ -89,7 +88,7 @@ fn parse_version_str(version_str: &str) -> Result<Version> {
     let clean_version = if version_str.starts_with('v') {
         version_str.get(1..).unwrap()
     } else {
-        version_str.borrow()
+        version_str
     };
 
     Version::parse(clean_version).context(version_str.to_owned())
@@ -252,7 +251,7 @@ impl InstalledNodeVersion {
     pub fn find_matching(config: &Config, range: &Range) -> Option<InstalledNodeVersion> {
         Self::list(config)
             .iter()
-            .find(|inv| range.satisfies(inv.version().borrow()))
+            .find(|inv| range.satisfies(inv.version()))
             .map(|inv| inv.to_owned())
     }
 }

--- a/src/subcommand/install.rs
+++ b/src/subcommand/install.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, path::Path, time::Duration};
+use std::{path::Path, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -59,7 +59,7 @@ impl Action<InstallCommand> for InstallCommand {
         }
 
         let install_path = version_to_install.install_path(config);
-        download_and_extract_to(version_to_install.borrow(), &install_path)?;
+        download_and_extract_to(version_to_install, &install_path)?;
 
         if config.force
             || (options.switch

--- a/src/subcommand/install.rs
+++ b/src/subcommand/install.rs
@@ -78,7 +78,9 @@ impl Action<InstallCommand> for InstallCommand {
 
         if options.enable_corepack {
             if let Err(e) = std::process::Command::new(
-                install_path.join(format!("corepack{}", utils::exec_ext())),
+                install_path
+                    .join("bin")
+                    .join(format!("corepack{}", utils::exec_ext())),
             )
             .arg("enable")
             .output()

--- a/tests/install_test.rs
+++ b/tests/install_test.rs
@@ -8,7 +8,7 @@ mod install {
     fn can_install_version_matching_range() -> Result<()> {
         let (temp_dir, mut cmd) = utils::setup_integration_test()?;
 
-        let version_range = ">=12, <12.8";
+        let version_range = ">=14, <14.21";
         let result = cmd
             .arg("install")
             .arg("--force")
@@ -17,10 +17,10 @@ mod install {
 
         utils::assert_outputs_contain(
             &result,
-            "Downloading from https://nodejs.org/dist/v12.7.0/node-v12.7.0-",
+            "Downloading from https://nodejs.org/dist/v14.20.1/node-v14.20.1-",
             "",
         )?;
-        utils::assert_version_installed(&temp_dir, "12.7.0", true)?;
+        utils::assert_version_installed(&temp_dir, "14.20.1", true)?;
 
         temp_dir.close().map_err(anyhow::Error::from)
     }
@@ -29,12 +29,12 @@ mod install {
     fn can_install_version_matching_exact_version() -> Result<()> {
         let (temp_dir, mut cmd) = utils::setup_integration_test()?;
 
-        let version_str = "12.18.3";
+        let version_str = "14.21.2";
         let result = cmd.arg("install").arg("--force").arg(version_str).assert();
 
         utils::assert_outputs_contain(
             &result,
-            "Downloading from https://nodejs.org/dist/v12.18.3/node-v12.18.3-",
+            "Downloading from https://nodejs.org/dist/v14.21.2/node-v14.21.2-",
             "",
         )?;
         utils::assert_version_installed(&temp_dir, version_str, true)?;
@@ -46,12 +46,12 @@ mod install {
     fn stops_when_installing_installed_version() -> Result<()> {
         let (temp_dir, mut cmd) = utils::setup_integration_test()?;
 
-        let version_str = "12.18.3";
+        let version_str = "14.21.2";
         utils::install_mock_version(&temp_dir, version_str)?;
 
         let result = cmd.arg("install").arg(version_str).assert();
 
-        utils::assert_outputs_contain(&result, "12.18.3 is already installed - skipping...", "")?;
+        utils::assert_outputs_contain(&result, "14.21.2 is already installed - skipping...", "")?;
 
         temp_dir.close().map_err(anyhow::Error::from)
     }
@@ -60,12 +60,12 @@ mod install {
     fn force_forces_install_of_installed_version() -> Result<()> {
         let (temp_dir, mut cmd) = utils::setup_integration_test()?;
 
-        let version_str = "12.18.3";
+        let version_str = "14.21.2";
         let result = cmd.arg("install").arg("--force").arg(version_str).assert();
 
         utils::assert_outputs_contain(
             &result,
-            "Downloading from https://nodejs.org/dist/v12.18.3/node-v12.18.3-",
+            "Downloading from https://nodejs.org/dist/v14.21.2/node-v14.21.2-",
             "",
         )?;
         utils::assert_outputs_contain(&result, "Extracting...", "")?;


### PR DESCRIPTION
- Fixes the path to the `corepack` executable
- Fixes ARM Macs downloading x64 versions instead of ARM